### PR TITLE
Add support for generic message types

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,5 +98,4 @@ Closing a `Relay` and `Listener`s can be done concurrently in a safe manner.
 	time.Sleep(time.Second)                                // Allow time for previous messages to be processed
 	relay.Broadcast(msgC)                                  // Send notification without guaranteed delivery
 	time.Sleep(time.Second)                                // Allow time for previous messages to be processed
-	relay.Close()      
 ```

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 ![CI](https://github.com/teivah/broadcast/actions/workflows/ci.yml/badge.svg)
 [![Go Report Card](https://goreportcard.com/badge/github.com/teivah/broadcast)](https://goreportcard.com/report/github.com/teivah/broadcast)
 
-Notifications broadcaster in Go
+Notification broadcaster in Go
 
 ## What?
 
-`broadcast` is a library that allows sending repeated notifications to multiple goroutines with guaranteed delivery.
+`broadcast` is a library that allows sending repeated notifications to multiple goroutines with guaranteed delivery and user defined types.
 
 ## Why?
 
@@ -15,7 +15,7 @@ Notifications broadcaster in Go
 
 The standard way to handle notifications is via a `chan struct{}`. However, sending a message to a channel is received by a single goroutine. 
 
-The only operation that is broadcasted to multiple goroutines is a channel closure. Yet, if the channel is closed, there's no way to send a message again.
+The only operation that is broadcast to multiple goroutines is a channel closure. Yet, if the channel is closed, there's no way to send a message again.
 
 ❌ Repeated notifications to multiple goroutines
 
@@ -35,22 +35,22 @@ There's one caveat to keep in mind, though: the `Broadcast()` method doesn't gua
 
 ### Step by Step
 
-First, we need to create a `Relay`:
+First, we need to create a `Relay` for a message type (empty struct in this case):
 
 ```go
-relay := broadcast.NewRelay()
+relay := broadcast.NewRelay[struct{}]()
 ```
 
-Once a `Relay` is created, we can create a new listener using the `Listen` method. As the `broadcast` library relies internally on channels, it accepts a capacity:
+Once a `Relay` is created, we can create a new listener using the `Listener` method. As the `broadcast` library relies internally on channels, it accepts a capacity:
 
 ````go
 list := relay.Listener(1) // Create a new listener based on a channel with a one capacity
 ````
 
 A `Relay` can send a notification in three different manners:
-* `Notify()`: block until a notification is sent to all the listeners
-* `NotifyCtx(context.Context)`: send a notification to all the listeners unless the provided context times out or is canceled
-* `Broadcast()`: send a notification to all the listeners in a non-blocking manner; guaranteed delivery isn't guaranteed
+* `Notify`: block until a notification is sent to all the listeners
+* `NotifyCtx`: send a notification to all listeners unless the provided context times out or is canceled
+* `Broadcast`: send a notification to all listeners in a non-blocking manner; delivery isn't guaranteed
 
 On the `Listener` side, we can access the internal channel using `Ch`:
 
@@ -70,29 +70,33 @@ Closing a `Relay` and `Listener`s can be done concurrently in a safe manner.
 ### Example
 
 ```go
-relay := broadcast.NewRelay() // Create a relay
-defer relay.Close()
+	type msg string
+	const (
+		msgA msg = "A"
+		msgB     = "B"
+		msgC     = "C"
+	)
 
-list1 := relay.Listener(1) // Create a listener with one capacity
-defer list1.Close()
-list2 := relay.Listener(1) // Create a listener with one capacity
-defer list2.Close()
+	relay := broadcast.NewRelay[msg]() // Create a relay for msg values
+	defer relay.Close()
 
-// Listener goroutines
-f := func(i int, list *broadcast.Listener) {
-    for range list.Ch() { // Waits for receiving notifications
-        fmt.Printf("listener %d has received a notification\n", i)
-    }
-}
-go f(1, list1)
-go f(2, list2)
+	// Listener goroutines
+	for i := 0; i < 2; i++ {
+		go func(i int) {
+			l := relay.Listener(1)  // Create a listener with a buffer capacity of 1
+			for n := range l.Ch() { // Ranges over notifications
+				fmt.Printf("listener %d has received a notification: %v\n", i, n)
+			}
+		}(i)
+	}
 
-// Notifier goroutine
-for i := 0; i < 5; i++ {
-time.Sleep(time.Second)
-    relay.Notify() // Send notifications with guaranteed delivery
-    ctx, _ := context.WithTimeout(context.Background(), time.Second)
-    relay.NotifyCtx(ctx) // Send notifications but cancel after 1 second
-    relay.Broadcast()    // Send notifications without guaranteed delivery
-}
+	// Notifiers
+	time.Sleep(time.Second)
+	relay.Notify(msgA)                                     // Send notification with guaranteed delivery
+	ctx, _ := context.WithTimeout(context.Background(), 0) // Context with immediate timeout
+	relay.NotifyCtx(ctx, msgB)                             // Send notification respecting context cancellation
+	time.Sleep(time.Second)                                // Allow time for previous messages to be processed
+	relay.Broadcast(msgC)                                  // Send notification without guaranteed delivery
+	time.Sleep(time.Second)                                // Allow time for previous messages to be processed
+	relay.Close()      
 ```

--- a/broadcast.go
+++ b/broadcast.go
@@ -7,38 +7,38 @@ import (
 )
 
 // Relay is the struct in charge of handling the listeners and dispatching the notifications.
-type Relay struct {
+type Relay[T any] struct {
 	mu      sync.RWMutex
 	n       uint32
-	clients map[uint32]*Listener
+	clients map[uint32]*Listener[T]
 }
 
 // NewRelay is the factory to create a Relay.
-func NewRelay() *Relay {
-	return &Relay{
-		clients: make(map[uint32]*Listener),
+func NewRelay[T any]() *Relay[T] {
+	return &Relay[T]{
+		clients: make(map[uint32]*Listener[T]),
 	}
 }
 
 // Notify sends a notification to all the listeners.
 // It guarantees that all the listeners will receive the notification.
-func (r *Relay) Notify() {
+func (r *Relay[T]) Notify(v T) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
 	for _, client := range r.clients {
-		client.ch <- struct{}{}
+		client.ch <- v
 	}
 }
 
 // NotifyCtx tries sending a notification to all the listeners until the context times out or is canceled.
-func (r *Relay) NotifyCtx(ctx context.Context) {
+func (r *Relay[T]) NotifyCtx(ctx context.Context, v T) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
 	for _, client := range r.clients {
 		select {
-		case client.ch <- struct{}{}:
+		case client.ch <- v:
 		case <-ctx.Done():
 			return
 		}
@@ -47,25 +47,25 @@ func (r *Relay) NotifyCtx(ctx context.Context) {
 
 // Broadcast broadcasts a notification to all the listeners.
 // The notification is sent in a non-blocking manner, so there's no guarantee that a listener receives it.
-func (r *Relay) Broadcast() {
+func (r *Relay[T]) Broadcast(v T) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
 	for _, client := range r.clients {
 		select {
-		case client.ch <- struct{}{}:
+		case client.ch <- v:
 		default:
 		}
 	}
 }
 
 // Listener creates a new listener given a channel capacity.
-func (r *Relay) Listener(capacity int) *Listener {
+func (r *Relay[T]) Listener(capacity int) *Listener[T] {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	listener := &Listener{
-		ch:    make(chan struct{}, capacity),
+	listener := &Listener[T]{
+		ch:    make(chan T, capacity),
 		id:    r.n,
 		relay: r,
 	}
@@ -76,7 +76,7 @@ func (r *Relay) Listener(capacity int) *Listener {
 
 // Close closes a relay.
 // This operation can be safely called in the meantime as Listener.Close()
-func (r *Relay) Close() {
+func (r *Relay[T]) Close() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -86,14 +86,14 @@ func (r *Relay) Close() {
 	r.clients = nil
 }
 
-func (r *Relay) closeRelay(l *Listener) {
+func (r *Relay[T]) closeRelay(l *Listener[T]) {
 	l.once.Do(func() {
 		close(l.ch)
 		delete(r.clients, l.id)
 	})
 }
 
-func (r *Relay) closeListener(l *Listener) {
+func (r *Relay[T]) closeListener(l *Listener[T]) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -102,21 +102,21 @@ func (r *Relay) closeListener(l *Listener) {
 }
 
 // Listener is a Relay listener.
-type Listener struct {
-	ch    chan struct{}
+type Listener[T any] struct {
+	ch    chan T
 	id    uint32
-	relay *Relay
+	relay *Relay[T]
 	once  sync.Once
 }
 
 // Ch returns the Listener channel.
-func (l *Listener) Ch() <-chan struct{} {
+func (l *Listener[T]) Ch() <-chan T {
 	return l.ch
 }
 
 // Close closes a listener.
 // This operation can be safely called in the meantime as Relay.Close()
-func (l *Listener) Close() {
+func (l *Listener[T]) Close() {
 	l.once.Do(func() {
 		l.relay.closeListener(l)
 	})

--- a/broadcast_test.go
+++ b/broadcast_test.go
@@ -44,51 +44,6 @@ func TestNotify(t *testing.T) {
 	relay.Close()
 }
 
-func TestNotify2(t *testing.T) {
-	type Msg string
-	const msgA Msg = "A"
-	const msgB Msg = "B"
-
-	relay := broadcast.NewRelay[Msg]()
-	list1 := relay.Listener(0)
-	list2 := relay.Listener(0)
-	wg := sync.WaitGroup{}
-
-	wg.Add(2)
-	go func() {
-		select {
-		case msg := <-list1.Ch():
-			if msg == msgA {
-				
-			}
-		}
-		wg.Done()
-	}()
-	go func() {
-		<-list2.Ch()
-		wg.Done()
-	}()
-	relay.Notify(msgA)
-	wg.Wait()
-
-	wg.Add(1)
-	go func() {
-		<-list2.Ch()
-		wg.Done()
-	}()
-	list1.Close()
-	relay.Notify(msgA)
-	wg.Wait()
-
-	list2.Close()
-	relay.Notify(msgB)
-
-	list1.Close()
-	list2.Close()
-
-	relay.Close()
-}
-
 func TestBroadcast(t *testing.T) {
 	relay := broadcast.NewRelay[struct{}]()
 	relay.Listener(0)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/teivah/broadcast
 
-go 1.16
+go 1.18


### PR DESCRIPTION
Ties Relay and Listener to a `[T any]` allowing users to pass any type as a notification message instead of being limited to an empty struct.